### PR TITLE
Fixed check box issue on completion/non-completion of todo

### DIFF
--- a/src/components/Todo.jsx
+++ b/src/components/Todo.jsx
@@ -30,7 +30,7 @@ const TodoInput = styled(Input)`
 export const Todo = ({ complete = false, value = '', index, save, create, disabled = false }) => {
   const [input, setInput] = useState(value);
   const [focused, setFocused] = useState(false);
-  const [completeTick, setcCompleteTick] = useState(complete);
+  const [completeTick, setCompleteTick] = useState(complete);
 
   const doSave = () => {
     if (!disabled) {
@@ -60,7 +60,7 @@ export const Todo = ({ complete = false, value = '', index, save, create, disabl
                 value: input,
                 index,
               });
-              setcCompleteTick(!complete);
+              setCompleteTick(!complete);
             }
           }}
         >

--- a/src/components/Todo.jsx
+++ b/src/components/Todo.jsx
@@ -30,6 +30,7 @@ const TodoInput = styled(Input)`
 export const Todo = ({ complete = false, value = '', index, save, create, disabled = false }) => {
   const [input, setInput] = useState(value);
   const [focused, setFocused] = useState(false);
+  const [completeTick, setcCompleteTick] = useState(complete);
 
   const doSave = () => {
     if (!disabled) {
@@ -59,10 +60,11 @@ export const Todo = ({ complete = false, value = '', index, save, create, disabl
                 value: input,
                 index,
               });
+              setcCompleteTick(!complete);
             }
           }}
         >
-          {complete ? (
+          {completeTick ? (
             <CheckboxChecked cursor="pointer" display="inline-block" />
           ) : (
             <CheckboxUnchecked cursor="pointer" display="inline-block" />
@@ -80,7 +82,7 @@ export const Todo = ({ complete = false, value = '', index, save, create, disabl
             autoFocus={!value}
             isDisabled={disabled}
             style={{
-              textDecoration: complete ? 'line-through' : 'none',
+              textDecoration: completeTick ? 'line-through' : 'none',
             }}
             onFocus={() => setFocused(true)}
             onKeyDown={e => {


### PR DESCRIPTION
When a user completes a todo, the checkbox wasn't rendering the tick at the same time, unless the page was refreshed. So a <b>completeTick</b> state variable was created to handle the change of state of the todo.

```js
  const [completeTick, setCompleteTick] = useState(complete);
```
Thus, completeTick helps to handle the state of completion of todo on the current page without need of refreshing the page every time.